### PR TITLE
Fix missing podspec issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "files": [
     "dist/",
     "ios/Plugin/",
-    "AppIcon.podspec"
+    "CapacitorCommunityAppIcon.podspec"
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",


### PR DESCRIPTION
Fix wrong name of podspec which results in an error after running `npx cap sync` currently:

[!] No podspec found for `CapacitorCommunityAppIcon` in `../../node_modules/@capacitor-community/app-icon`