### PR TITLE
chore: Use version instead of branch for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["AppIconPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
It's recommended to set the Capacitor version instead of using main branch as if we publish a new 6.x version it will also be published in main branch, so sometimes main will have latest 7.x and sometimes latest 6.x