### PR TITLE
chore: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
       day: monday
       time: "08:00"
-      timezone: UTC
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,103 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: scope
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 1
+    groups:
+      capacitor:
+        patterns:
+          - "@capacitor/*"
+      tooling:
+        patterns:
+          - "@ionic/*"
+          - "@capacitor/docgen"
+          - eslint
+          - prettier
+          - prettier-plugin-java
+          - rimraf
+          - rollup
+          - swiftlint
+          - typescript
+
+  - package-ecosystem: npm
+    directory: /example
+    schedule:
+      interval: monthly
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(example-deps)"
+      include: scope
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 2
+    groups:
+      capacitor:
+        patterns:
+          - "@capacitor/*"
+      example-tooling:
+        patterns:
+          - "@stencil/*"
+          - "@ionic/*"
+
+  - package-ecosystem: gradle
+    directory: /android
+    schedule:
+      interval: monthly
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(android-deps)"
+      include: scope
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: gradle
+    directory: /example/android
+    schedule:
+      interval: monthly
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(example-android-deps)"
+      include: scope
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: monthly
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(ios-deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(ci-deps)"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@
 
 > Changing the app icon is only allowed when the app is in the foreground (iOS).
 
+
+## Dependency Updates
+
+This repository uses Dependabot for version update pull requests. Configuration lives in [`.github/dependabot.yml`](.github/dependabot.yml).
+
+- Ecosystems covered: npm (root and example), Gradle (plugin and example app), Swift Package Manager, and GitHub Actions.
+- Cadence: weekly for root npm and GitHub Actions, monthly for example app, Gradle, and Swift dependencies.
+- Grouping: high-churn dependency families such as `@capacitor/*` are grouped to reduce pull request noise.
+- Merge policy: all Dependabot pull requests are reviewed and merged manually.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This pull request introduces automated dependency management to the repository by adding a Dependabot configuration and updating the documentation to explain the new process. The main changes include the creation of a `.github/dependabot.yml` file to schedule and group dependency updates across multiple ecosystems, and a new section in the `README.md` describing how Dependabot is set up and managed.

**Dependabot configuration and documentation:**

* Added a comprehensive `.github/dependabot.yml` file to automate dependency updates for npm, Gradle, Swift, and GitHub Actions, including scheduling, grouping related dependencies, and customizing commit messages.
* Updated `README.md` to document the use of Dependabot, detailing which ecosystems are covered, update frequency, grouping strategy, and the manual review policy for dependency update pull requests.